### PR TITLE
Remove Squiz.Strings.DoubleQuoteUsage

### DIFF
--- a/DDC/ruleset.xml
+++ b/DDC/ruleset.xml
@@ -50,7 +50,4 @@
 
 	<!-- Code Conversion -->
 	<rule ref="Squiz.ControlStructures.ElseIfDeclaration"/>
-
-	<!-- Others -->
-	<rule ref="Squiz.Strings.DoubleQuoteUsage"/>
 </ruleset>


### PR DESCRIPTION
This rule seems to be a bit overreaching, it disallows variable use in double quote strings in favour of single quoting everything and using concatenation. I don't think this is a top priority and is adding extra work at this time.